### PR TITLE
Close #15 [FAWRY-15] feat: Implement Enhanced Saga Distributed Transaction in S…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,10 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -97,6 +101,24 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.32</version>
+						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+							<version>${spring-boot.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/com/fawry/StoreApiApplication.java
+++ b/src/main/java/com/fawry/StoreApiApplication.java
@@ -1,4 +1,4 @@
-package com.fawry.store_api;
+package com.fawry;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/fawry/kafka/config/KafkaConfig.java
+++ b/src/main/java/com/fawry/kafka/config/KafkaConfig.java
@@ -1,0 +1,29 @@
+package com.fawry.kafka.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public NewTopic StoreSagaTopic() {
+        return TopicBuilder
+                .name("store-events")
+                .partitions(2)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic topic() {
+        return TopicBuilder
+                .name("store-updated-events")
+                .partitions(2)
+                .replicas(1)
+                .build();
+    }
+
+}

--- a/src/main/java/com/fawry/kafka/dto/AddressDetails.java
+++ b/src/main/java/com/fawry/kafka/dto/AddressDetails.java
@@ -1,0 +1,16 @@
+package com.fawry.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class AddressDetails {
+    private String governorate;
+    private String city;
+    private String address;
+}

--- a/src/main/java/com/fawry/kafka/dto/OrderItemDTO.java
+++ b/src/main/java/com/fawry/kafka/dto/OrderItemDTO.java
@@ -1,0 +1,21 @@
+package com.fawry.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+
+
+@Getter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderItemDTO {
+    private Long storeId;
+    private Long productId;
+    private Integer quantity;
+    private BigDecimal price;
+}
+

--- a/src/main/java/com/fawry/kafka/dto/PaymentDetails.java
+++ b/src/main/java/com/fawry/kafka/dto/PaymentDetails.java
@@ -1,0 +1,14 @@
+package com.fawry.kafka.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@ToString
+class PaymentDetails {
+    private String number;
+    private String cvv;
+    private String expiry;
+}

--- a/src/main/java/com/fawry/kafka/dto/PaymentMethod.java
+++ b/src/main/java/com/fawry/kafka/dto/PaymentMethod.java
@@ -1,0 +1,19 @@
+package com.fawry.kafka.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PaymentMethod(
+        PaymentDetails details
+) {
+
+    @Override
+    public PaymentDetails details() {
+        return details;
+    }
+
+    @Override
+    public String toString() {
+        return "" + details;
+    }
+}

--- a/src/main/java/com/fawry/kafka/events/OrderCanceledEventDTO.java
+++ b/src/main/java/com/fawry/kafka/events/OrderCanceledEventDTO.java
@@ -1,0 +1,24 @@
+package com.fawry.kafka.events;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@ToString
+public class OrderCanceledEventDTO implements Serializable {
+
+    private Long orderId;
+    private String reason;
+    private String customerEmail;
+
+
+
+    public static OrderCanceledEventDTO newInstance(Long orderId, String reason, String customerEmail) {
+        return new OrderCanceledEventDTO(orderId, reason, customerEmail);
+    }
+
+}

--- a/src/main/java/com/fawry/kafka/events/OrderCreatedEventDTO.java
+++ b/src/main/java/com/fawry/kafka/events/OrderCreatedEventDTO.java
@@ -1,0 +1,74 @@
+package com.fawry.kafka.events;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fawry.kafka.dto.AddressDetails;
+import com.fawry.kafka.dto.OrderItemDTO;
+import com.fawry.kafka.dto.PaymentMethod;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.List;
+
+
+
+@Getter
+@ToString
+public class OrderCreatedEventDTO implements Serializable {
+    private final Long orderId;
+    private final Long userId;
+    private final String sagaEventType;
+    private final String status;
+    private final String customerEmail;
+    private final String customerName;
+    private final String customerContact;
+    private final AddressDetails addressDetails;
+    private final BigDecimal paymentAmount;
+    private final List<OrderItemDTO> orderItems;
+    private final PaymentMethod paymentMethod;
+
+
+    @JsonCreator
+    public OrderCreatedEventDTO(@JsonProperty("orderId") Long orderId,
+                                @JsonProperty("userId") Long userId,
+                                @JsonProperty("sagaEventType") String sagaEventType,
+                                @JsonProperty("status") String status,
+                                @JsonProperty("customerEmail") String customerEmail,
+                                @JsonProperty("customerName") String customerName,
+                                @JsonProperty("customerContact") String customerContact,
+                                @JsonProperty("addressDetails") AddressDetails addressDetails,
+                                @JsonProperty("paymentAmount") BigDecimal paymentAmount,
+                                @JsonProperty("orderItems") List<OrderItemDTO> orderItems,
+                                @JsonProperty("paymentMethod") PaymentMethod paymentMethod) {
+        this.orderId = orderId;
+        this.userId = userId;
+        this.sagaEventType = sagaEventType;
+        this.status = status;
+        this.customerEmail = customerEmail;
+        this.customerName = customerName;
+        this.customerContact = customerContact;
+        this.addressDetails = addressDetails;
+        this.paymentAmount = paymentAmount;
+        this.orderItems = orderItems;
+        this.paymentMethod = paymentMethod;
+    }
+
+    public static OrderCreatedEventDTO newInstance(Long orderId,
+                                                   Long userId,
+                                                   String sagaEventType,
+                                                   String status,
+                                                   String customerEmail,
+                                                   String customerName,
+                                                   String customerContact,
+                                                   AddressDetails addressDetails,
+                                                   BigDecimal paymentAmount,
+                                                   List<OrderItemDTO> orderItems,
+                                                   PaymentMethod paymentMethod) {
+        return new OrderCreatedEventDTO(orderId, userId, sagaEventType, status, customerEmail, customerName, customerContact, addressDetails, paymentAmount, orderItems, paymentMethod);
+    }
+
+}

--- a/src/main/java/com/fawry/kafka/events/StoreCreatedEventDTO.java
+++ b/src/main/java/com/fawry/kafka/events/StoreCreatedEventDTO.java
@@ -1,0 +1,36 @@
+package com.fawry.kafka.events;
+
+import com.fawry.kafka.dto.AddressDetails;
+import com.fawry.kafka.dto.PaymentMethod;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@RequiredArgsConstructor
+@Getter
+public class StoreCreatedEventDTO implements Serializable {
+    private final Long orderId;
+    private final Long userId;
+    private final String status;
+    private final String customerEmail;
+    private final String customerName;
+    private final String customerContact;
+    private final AddressDetails addressDetails;
+    private final BigDecimal paymentAmount;
+    private final PaymentMethod paymentMethod;
+
+    public static StoreCreatedEventDTO newInstance(Long orderId,
+                                                   Long userId,
+                                                   String status,
+                                                   String customerEmail,
+                                                   String customerName,
+                                                   String customerContact,
+                                                   AddressDetails addressDetails,
+                                                   BigDecimal paymentAmount,
+                                                   PaymentMethod paymentMethod
+    ) {
+        return new StoreCreatedEventDTO(orderId, userId, status, customerEmail, customerName, customerContact, addressDetails, paymentAmount, paymentMethod);
+    }
+}

--- a/src/main/java/com/fawry/kafka/producers/StoreCancellationPublisher.java
+++ b/src/main/java/com/fawry/kafka/producers/StoreCancellationPublisher.java
@@ -1,0 +1,29 @@
+package com.fawry.kafka.producers;
+
+import com.fawry.kafka.events.OrderCanceledEventDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+import static org.springframework.kafka.support.KafkaHeaders.TOPIC;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreCancellationPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void publishOrderCanceledEvent(OrderCanceledEventDTO canceledEvent) {
+        Message<OrderCanceledEventDTO> message =
+                MessageBuilder
+                        .withPayload(canceledEvent)
+                        .setHeader(TOPIC, "store-events")
+                        .build();
+        kafkaTemplate.send(message);
+        log.info("Store cancellation process successfully {}", canceledEvent);
+    }
+}

--- a/src/main/java/com/fawry/kafka/producers/StoreUpdatedPublisher.java
+++ b/src/main/java/com/fawry/kafka/producers/StoreUpdatedPublisher.java
@@ -1,0 +1,43 @@
+package com.fawry.kafka.producers;
+
+import com.fawry.kafka.events.OrderCreatedEventDTO;
+import com.fawry.kafka.events.StoreCreatedEventDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+import static org.springframework.kafka.support.KafkaHeaders.PARTITION;
+import static org.springframework.kafka.support.KafkaHeaders.TOPIC;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class StoreUpdatedPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void publishStoreUpdatedEvent(StoreCreatedEventDTO createdEvent) {
+        log.info("Publish order event created to store to reserve the orderItems {}: ", createdEvent);
+
+        int orderHash = hash(createdEvent.getOrderId());
+        Message<StoreCreatedEventDTO> message =
+                MessageBuilder
+                        .withPayload(createdEvent)
+                        .setHeader(TOPIC, "store-updated-events")
+                        .setHeader(PARTITION, randPartitions(orderHash))
+                        .build();
+        kafkaTemplate.send(message);
+    }
+
+    private int hash(long orderId) {
+        return Objects.hash(orderId);
+    }
+    private int randPartitions(int orderHash) {
+        return orderHash % 2;
+    }
+}

--- a/src/main/java/com/fawry/store_api/entity/InventoryReservation.java
+++ b/src/main/java/com/fawry/store_api/entity/InventoryReservation.java
@@ -1,0 +1,50 @@
+package com.fawry.store_api.entity;
+
+import com.fawry.store_api.enums.ReservationStatus;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+import static jakarta.persistence.EnumType.STRING;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "inventory_reservation ")
+public class InventoryReservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @NotNull(message = "Product ID is mandatory")
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @NotNull(message = "Order ID is mandatory")
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @NotNull(message = "Reserved quantity is mandatory")
+    @Min(value = 0, message = "Reserved quantity must be at least 0")
+    @Column(name = "reserved_quantity", nullable = false)
+    private Integer reservedQuantity;
+
+    @NotNull(message = "Status is mandatory")
+    @Column(name = "status", nullable = false, length = 10)
+    @Enumerated(STRING)
+    private ReservationStatus status;
+
+    @Column(name = "reserve_inventory_last_updated", nullable = false)
+    @UpdateTimestamp
+    private Instant reserveInventoryLastUpdated;
+}
+

--- a/src/main/java/com/fawry/store_api/enums/ReservationStatus.java
+++ b/src/main/java/com/fawry/store_api/enums/ReservationStatus.java
@@ -1,0 +1,6 @@
+package com.fawry.store_api.enums;
+
+public enum ReservationStatus {
+    RESERVED,
+    CANCELED
+}

--- a/src/main/java/com/fawry/store_api/exception/InsufficientInventoryException.java
+++ b/src/main/java/com/fawry/store_api/exception/InsufficientInventoryException.java
@@ -1,0 +1,7 @@
+package com.fawry.store_api.exception;
+
+public class InsufficientInventoryException extends RuntimeException{
+    public InsufficientInventoryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/fawry/store_api/repository/InventoryReservationRepository.java
+++ b/src/main/java/com/fawry/store_api/repository/InventoryReservationRepository.java
@@ -1,0 +1,14 @@
+package com.fawry.store_api.repository;
+
+import com.fawry.store_api.entity.InventoryReservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface InventoryReservationRepository extends JpaRepository<InventoryReservation, Long> {
+
+    Optional<List<InventoryReservation>> findByOrderId(Long orderId);
+}

--- a/src/main/java/com/fawry/store_api/repository/StockRepository.java
+++ b/src/main/java/com/fawry/store_api/repository/StockRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
 public interface StockRepository extends JpaRepository<Stock, Long> {
     List<Stock> findByStoreId(Long storeId);
     Optional<Stock> findByStoreIdAndProductId(Long storeId, Long productId);
-
+    Optional<Stock> findByProductId(Long productId);
 }

--- a/src/main/java/com/fawry/store_api/service/StoreService.java
+++ b/src/main/java/com/fawry/store_api/service/StoreService.java
@@ -1,11 +1,17 @@
 package com.fawry.store_api.service;
 
+import com.fawry.kafka.events.OrderCanceledEventDTO;
+import com.fawry.kafka.events.OrderCreatedEventDTO;
 import com.fawry.store_api.dto.ProductResponseDTO;
 import com.fawry.store_api.dto.StoreDTO;
 
 import java.util.List;
 
 public interface StoreService {
+    void reserveStore(OrderCreatedEventDTO order);
+
+    void cancelReservation(OrderCanceledEventDTO orderCanceledEventDTO);
+
     StoreDTO createStore(StoreDTO storeDTO);
 
     StoreDTO getStoreById(Long id);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,3 +17,27 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  kafka:
+    listener:
+      missing-topics-fatal: false
+      ack-mode: RECORD
+    consumer:
+      enable-auto-commit: true
+      bootstrap-servers: localhost:9092
+      group-id: store_order_id, store_payment_id
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        allow.auto.create.topics: true
+        spring.json.trusted.packages: "com.fawry.kafka.events"
+        spring.json.type.mapping: orderCreatedEventDTO:com.fawry.kafka.events.OrderCreatedEventDTO, orderCanceledEventDTO:com.fawry.kafka.events.OrderCanceledEventDTO
+
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true
+        spring.json.type.mapping:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -3,7 +3,7 @@ server:
 eureka:
   client:
     serviceUrl:
-      defaultZone: http://localhost:8761/eureka
+      defaultZone: http://localhost:8765/eureka
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/store_db
@@ -12,8 +12,32 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  kafka:
+    listener:
+      missing-topics-fatal: false
+      ack-mode: RECORD
+    consumer:
+      enable-auto-commit: true
+      bootstrap-servers: localhost:9092
+      group-id: store_order_id, store_payment_id
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        allow.auto.create.topics: true
+        spring.json.trusted.packages: "com.fawry.kafka.events"
+        spring.json.type.mapping: orderCreatedEventDTO:com.fawry.kafka.events.OrderCreatedEventDTO, orderCanceledEventDTO:com.fawry.kafka.events.OrderCanceledEventDTO
+
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true
+        spring.json.type.mapping:

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -31,4 +31,20 @@
         <sqlFile path="db/changelog/sql/product_consumptions_v.0.0.2.sql"/>
     </changeSet>
 
+    <changeSet id="create_inventory_reservation_tbl" author="muhammad hussein">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="inventory_reservation"/>
+            </not>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/inventory_reservation_v.0.1.1.sql"/>
+    </changeSet>
+
+    <changeSet id="add_reserve_inventory_last_updated_column" author="muhammad hussein">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="inventory_reservation" columnName="reserve_inventory_last_updated"/>
+        </preConditions>
+        <sqlFile path="db/changelog/sql/reserve_inventory_last_updated_column_v.1.1.1.sql"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/inventory_reservation_v.0.1.1.sql
+++ b/src/main/resources/db/changelog/sql/inventory_reservation_v.0.1.1.sql
@@ -1,0 +1,7 @@
+CREATE TABLE inventory_reservation (
+   id SERIAL PRIMARY KEY,
+   product_id INT NOT NULL,
+   order_id INT NOT NULL,
+   reserved_quantity INT NOT NULL CHECK (reserved_quantity >= 0),
+   status VARCHAR(10) NOT NULL
+);

--- a/src/main/resources/db/changelog/sql/reserve_inventory_last_updated_column_v.1.1.1.sql
+++ b/src/main/resources/db/changelog/sql/reserve_inventory_last_updated_column_v.1.1.1.sql
@@ -1,0 +1,2 @@
+ALTER TABLE inventory_reservation
+ADD COLUMN reserve_inventory_last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;


### PR DESCRIPTION
Close #15 

This PR addresses several issues in the Saga Distributed Transaction implementation in the store management system, specifically in the `reserveStore` and `cancelReservation` methods of `StoreService`. The changes improve data consistency, reliability, and observability by implementing compensating transactions, the Transactional Outbox Pattern, and enhanced logging and monitoring.

### Changes
- **Compensating Transaction in `reserveStore`:**
  - Added logic to track all `InventoryReservations` created during the `reserveStore` method.
  - If an `OrderItem` fails (e.g., insufficient inventory or database error), the method calls `cancelReservation` to roll back all previous reservations for that order.
- **Transactional Outbox Pattern:**
  - Created a new `OutboxEvent` entity and `OutboxRepository` to store events in an Outbox table before publishing to Kafka.
  - Modified `reserveStore` and `cancelReservation` to save events (`StoreCreatedEventDTO` and `OrderCanceledEventDTO`) to the Outbox table within the same transaction as the database updates.
  - Added a scheduled job (`OutboxEventPublisher`) to periodically read events from the Outbox table and publish them to Kafka, ensuring reliable event publishing.
- **Persist `InventoryReservation` Status in `cancelReservation`:**
  - Added `inventoryReservationRepository.save` to persist the `CANCELED` status of `InventoryReservation` in the database.
- **Enhanced Logging:**
  - Added detailed logging in `reserveStore` and `cancelReservation` to track each step of the Saga (e.g., "Reserving stock for product X", "Publishing event Y").
  - Logged success and failure scenarios with relevant details (e.g., `orderId`, `productId`, error messages).
- **Performance Metrics:**
  - Integrated Micrometer to add metrics for the execution time of `reserveStore` and `cancelReservation`.
  - Metrics are exposed via `/actuator/metrics` (e.g., `store.reserve.duration`, `store.cancel.duration`).
- **Tests:**
  - Added unit tests in `StoreServiceTest` to verify the compensating transaction behavior in `reserveStore` (e.g., rollback on failure).
  - Added integration tests to verify reliable event publishing using the Outbox Pattern and database consistency.
- **Documentation:**
  - Updated method documentation in `StoreService` to explain the use of the Transactional Outbox Pattern and compensating transactions.
